### PR TITLE
Peerdependency sync on merge

### DIFF
--- a/.github/workflows/package-bump-pr.yml
+++ b/.github/workflows/package-bump-pr.yml
@@ -51,12 +51,25 @@ jobs:
 
       - name: lerna - Bump packages
         run: |
+          # bump versions of packages
           npx lerna version --yes --no-push --conventional-commits
           if [[ $(git rev-list --count @{u}..HEAD) -ne 0 ]] ; then
+            # Synchronize @spinnaker/pluginsdk-peerdeps
+            cd packages/pluginsdk-peerdeps
+            yarn sync
+            # navigate back to root
+            cd ../..
+
+            # bump version of @spinnaker/pluginsdk-peerdeps but don't commit changes
+            npx lerna version --yes --no-push --conventional-commits --no-git-tag-version
+            git add packages/pluginsdk-peerdeps
+
+            # Update yarn.lock
             yarn
             git add yarn.lock
-            # Update yarn.lock and fix the lerna commit message (to use conventional commits itself)
-            git commit --amend -m "$(git log -1 --pretty=%B | sed -e 's/^Publish/chore(publish): publish packages/')" yarn.lock
+
+            # Amend yarn.lock and @spinnaker/pluginsdk-peerdeps to original lerna commit message using conventional commits
+            git commit --amend -m "$(git log -1 --pretty=%B | sed -e 's/^Publish/chore(publish): publish packages/')"
           fi
 
       - name: gha - get bumped packages

--- a/.github/workflows/package-bump-pr.yml
+++ b/.github/workflows/package-bump-pr.yml
@@ -52,24 +52,24 @@ jobs:
       - name: lerna - Bump packages
         run: |
           # bump versions of packages
-          npx lerna version --yes --no-push --conventional-commits
+          npx lerna version --yes --no-push --conventional-commits -m "chore(publish): publish packages"
           if [[ $(git rev-list --count @{u}..HEAD) -ne 0 ]] ; then
             # Synchronize @spinnaker/pluginsdk-peerdeps
             cd packages/pluginsdk-peerdeps
             yarn sync
+
             # navigate back to root
             cd ../..
 
-            # bump version of @spinnaker/pluginsdk-peerdeps but don't commit changes
-            npx lerna version --yes --no-push --conventional-commits --no-git-tag-version
-            git add packages/pluginsdk-peerdeps
-
-            # Update yarn.lock
+            # perform any updates to yarn.lock
             yarn
-            git add yarn.lock
 
-            # Amend yarn.lock and @spinnaker/pluginsdk-peerdeps to original lerna commit message using conventional commits
-            git commit --amend -m "$(git log -1 --pretty=%B | sed -e 's/^Publish/chore(publish): publish packages/')"
+            # commit changes
+            git add yarn.lock packages/pluginsdk-peerdeps
+            git commit -m "feat(peerdep-sync): Synchronize peerdependencies"
+
+            # bump version of @spinnaker/pluginsdk-peerdeps
+            npx lerna version --yes --no-push --conventional-commits -m "chore(publish): publish packages"
           fi
 
       - name: gha - get bumped packages


### PR DESCRIPTION
Adds some commands into the bump packages step to synchronize the peer dependencies in `@spinnaker/pluginsdk-peerdeps`